### PR TITLE
log int value as double for firebase analytics

### DIFF
--- a/src/android/FirebaseAnalyticsPlugin.java
+++ b/src/android/FirebaseAnalyticsPlugin.java
@@ -42,7 +42,7 @@ public class FirebaseAnalyticsPlugin extends ReflectiveCordovaPlugin {
             if (value instanceof String) {
                 bundle.putString(key, (String)value);
             } else if (value instanceof Integer) {
-                bundle.putInt(key, (Integer)value);
+                bundle.putDouble(key, Double.valueOf((Integer) value));
             } else if (value instanceof Double) {
                 bundle.putDouble(key, (Double)value);
             } else if (value instanceof Long) {


### PR DESCRIPTION
### Goal:
Log android analytics int values as doubles

### What I changed & why:
Log android analytics int values as doubles. This is to ensure that the values logged by both IOS and android are utilising the same data type. More details can be found in this [article](https://robertsahlin.com/firebase-logevents-as-doubles-in-a-webview/)

### How I know it works:
N/A

### Out of scope in this PR, but related:
N/A

### Notes for reviewers:
This PR is related to the issue: [https://github.com/cephalo-ai/pozole/issues/3864](https://github.com/cephalo-ai/pozole/issues/3864)
